### PR TITLE
Kubernetes ABAC policy file fix

### DIFF
--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -40,7 +40,7 @@ let
   });
 
   policyFile = pkgs.writeText "kube-policy"
-    concatStringsSep "\n" (map (builtins.toJSON cfg.apiserver.authorizationPolicy));
+    (concatStringsSep "\n" (map builtins.toJSON cfg.apiserver.authorizationPolicy));
 
   cniConfig = pkgs.buildEnv {
     name = "kubernetes-cni-config";


### PR DESCRIPTION
Fix the incorrect nix map that generates the Kubernetes policy file

###### Motivation for this change

Whenever you use the Kubernetes service with `services.kubernetes.apiserver.authorizationMode = "ABAC"` nixos fails to build due to an incorrectly defined map over `services.kubernetes.apiserver.authorizationPolicy`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

